### PR TITLE
Support for MATE DE and workaround for dual/multiple batteries

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Available options:
 + Shows battery charging animation.
 + Stop animation when battery is fully charged.
 + When not charging, icon changes according to battery percentage.
-+ Tested on *Openbox*, *i3wm*, *Fluxbox*, *Fvwm* & *Swaywm*.
++ Tested on *Openbox*, *i3wm*, *Fluxbox*, *Fvwm* *Swaywm* & *MATE*.
 
 ### Charging
 

--- a/battery_wall.sh
+++ b/battery_wall.sh
@@ -25,8 +25,8 @@ esac
 
 case "$OSTYPE" in 
 	darwin*) SETTER="wallpaper set" ;;
-	linux*) if [ -n "$SWAYSOCK" ]; then SETTER="eval ogurictl output '*' --image"; else SETTER="hsetroot -fill"; fi ;;
-	*) if [ -n "$SWAYSOCK" ]; then SETTER="eval ogurictl output '*' --image"; else SETTER="hsetroot -fill"; fi ;;
+	linux*) if [ -n "$SWAYSOCK" ]; then SETTER="eval ogurictl output '*' --image"; elif [[ "$DESKTOP_SESSION" = "mate" ]]; then SETTER="gsettings set org.mate.background picture-filename"; else SETTER="hsetroot -fill"; fi ;;
+	*) if [ -n "$SWAYSOCK" ]; then SETTER="eval ogurictl output '*' --image"; elif [[ "$DESKTOP_SESSION" = "mate" ]]; then SETTER="gsettings set org.mate.background picture-filename"; else SETTER="hsetroot -fill"; fi ;;
 esac
 
 ## Style 1 - Cartoon #############################################

--- a/battery_wall.sh
+++ b/battery_wall.sh
@@ -13,13 +13,13 @@ esac
 
 case "$OSTYPE" in
 	darwin*) BATTERY="$(pmset -g batt | egrep "([0-9]+\%).*" -o --colour=auto | cut -f1 -d';')" ;;
-	linux*) BATTERY="$(acpi | awk -F ' ' '{print $4}' | tr -d \%,)" ;;
+	linux*) BATTERY="$(acpi | awk -F ' ' 'END {print $4}' | tr -d \%,)" ;;
 	*) BATTERY_PERCENT="?" ;;
 esac
 
 case "$OSTYPE" in
 	darwin*) [[ $(pmset -g ps | head -1) =~ "AC Power" ]] && CHARGE=1 || CHARGE=0 ;;
-	linux*) CHARGE=$(acpi | awk -F ' ' '{print $3}' | tr -d \,) ;;
+	linux*) CHARGE=$(acpi | awk -F ' ' 'END {print $3}' | tr -d \,) ;;
 	*) CHARGE=0 ;;
 esac
 

--- a/test.sh
+++ b/test.sh
@@ -25,8 +25,8 @@ esac
 
 case "$OSTYPE" in 
 	darwin*) SETTER="wallpaper set" ;;
-	linux*) if [ -n "$SWAYSOCK" ]; then SETTER="eval ogurictl output '*' --image"; else SETTER="hsetroot -fill"; fi ;;
-	*) if [ -n "$SWAYSOCK" ]; then SETTER="eval ogurictl output '*' --image"; else SETTER="hsetroot -fill"; fi ;;
+	linux*) if [ -n "$SWAYSOCK" ]; then SETTER="eval ogurictl output '*' --image"; elif [[ "$DESKTOP_SESSION" = "mate" ]]; then SETTER="gsettings set org.mate.background picture-filename"; else SETTER="hsetroot -fill"; fi ;;
+	*) if [ -n "$SWAYSOCK" ]; then SETTER="eval ogurictl output '*' --image"; elif [[ "$DESKTOP_SESSION" = "mate" ]]; then SETTER="gsettings set org.mate.background picture-filename"; else SETTER="hsetroot -fill"; fi ;;
 esac
 
 ## Style 1 - Cartoon #############################################

--- a/test.sh
+++ b/test.sh
@@ -13,13 +13,13 @@ esac
 
 case "$OSTYPE" in
 	darwin*) BATTERY="$(pmset -g batt | egrep "([0-9]+\%).*" -o --colour=auto | cut -f1 -d';')" ;;
-	linux*) BATTERY="$(acpi | awk -F ' ' '{print $4}' | tr -d \%,)" ;;
+	linux*) BATTERY="$(acpi | awk -F ' ' 'END {print $4}' | tr -d \%,)" ;;
 	*) BATTERY_PERCENT="?" ;;
 esac
 
 case "$OSTYPE" in
 	darwin*) [[ $(pmset -g ps | head -1) =~ "AC Power" ]] && CHARGE=1 || CHARGE=0 ;;
-	linux*) CHARGE=$(acpi | awk -F ' ' '{print $3}' | tr -d \,) ;;
+	linux*) CHARGE=$(acpi | awk -F ' ' 'END {print $3}' | tr -d \,) ;;
 	*) CHARGE=0 ;;
 esac
 


### PR DESCRIPTION
This adds support for _MATE_ via _gsettings_ and adds a workaround for dual batteries by using only the last line of _acpi_. 
See [Commit Comment](https://github.com/adi1090x/battery-wallpaper/commit/4b6bcb3d522f91c5df82116a877979159c6cd2ca#comments) for more details

Tested on Manjaro