### PR TITLE
MacOS fix

### DIFF
--- a/battery_wall.sh
+++ b/battery_wall.sh
@@ -24,8 +24,10 @@ case "$OSTYPE" in
 esac
 
 ## For XFCE
-SCREEN="$(xrandr --listactivemonitors | awk -F ' ' 'END {print $1}' | tr -d \:)"
-MONITOR="$(xrandr --listactivemonitors | awk -F ' ' 'END {print $2}' | tr -d \*+)"
+if [[ "$OSTYPE" == "linux"* ]]; then
+    SCREEN="$(xrandr --listactivemonitors | awk -F ' ' 'END {print $1}' | tr -d \:)"
+    MONITOR="$(xrandr --listactivemonitors | awk -F ' ' 'END {print $2}' | tr -d \*+)"
+fi
 
 case "$OSTYPE" in 
 	darwin*) SETTER="wallpaper set" ;;

--- a/battery_wall.sh
+++ b/battery_wall.sh
@@ -12,7 +12,7 @@ case "$OSTYPE" in
 esac
 
 case "$OSTYPE" in
-	darwin*) BATTERY="$(pmset -g batt | egrep "([0-9]+\%).*" -o --colour=auto | cut -f1 -d';')" ;;
+	darwin*) BATTERY="$(pmset -g batt | egrep "([0-9]+\%).*" -o --colour=auto | cut -f1 -d';'| tr -d \%,)" ;;
 	linux*) BATTERY="$(acpi | awk -F ' ' 'END {print $4}' | tr -d \%,)" ;;
 	*) BATTERY_PERCENT="?" ;;
 esac


### PR DESCRIPTION
This PR intead to fix 2 bug
The 1st one is that xrandr isn't available on macOS, and windows 
```/usr/local/bin/bwall: line 27: xrandr: command not found```
The 2nd on is an error in my previous PR where I've forgot to escape the "%" char, and it was causing
```/usr/local/bin/bwall: line 131: [[: 100%: syntax error: operand expected (error token is "%")```
