### PR TITLE
Add cache check to the setter function

### DIFF
--- a/bwall.sh
+++ b/bwall.sh
@@ -173,6 +173,11 @@ set_wallpaper() {
 		{ reset_color; exit 1; }
 	fi
 
+  # check if image is the same as cache
+  if [[ $(cat "$cfile") == $image.$FORMAT ]]; then
+    return
+  fi
+
 	# set wallpaper with setter
 	if [[ -n "$FORMAT" ]]; then
 		$SETTER "$image.$FORMAT"


### PR DESCRIPTION
Regarding #22 I looked into the script and couldn't find anywhere where it leveraged that you cache the name of the current wallpaper. This PR implements a quick check to see whether the image should be updated or not. 

Feel free to correct me if I'm wrong or review the changes.